### PR TITLE
Post email notification and tests

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -67,7 +67,7 @@ livedata@1.0.13
 localstorage@1.0.3
 logging@1.0.7
 manuelschoebel:ms-seo@0.4.1
-matb33:collection-hooks@0.7.11
+matb33:collection-hooks@0.8.0
 meteor@1.1.6
 meteor-platform@1.2.2
 meteorhacks:fast-render@2.3.2

--- a/packages/custom/lib/server/Emails.js
+++ b/packages/custom/lib/server/Emails.js
@@ -1,0 +1,60 @@
+var EMAIL_FROM = 'noreply@textie.co';
+var EMAIL_TO = 'textieforward@gmail.com';
+var ROOT_URL = process.env.ROOT_URL;
+var LETTER_START = 'A';
+
+var fs = Npm.require('fs');
+var path = Npm.require('path');
+var assetsPath = path.join(process.cwd(), 'assets/packages/my-custom-package');
+
+var notificationEmailTemplate = fs.readFileSync(path.join(assetsPath,
+    'lib/server/emails/postNotificationEmail.html'), 'utf8');
+
+_.extend(Posts, {
+
+  /**
+   * @param {String} id - A post ID.
+   * @return {String} The URL for the given post.
+   */
+  getUrl: function(id) {
+    return url.resolve(ROOT_URL, 'posts/' + id);
+  },
+
+  /**
+   * Sends a notification email for the given post.
+   * @param {String} id - A post ID.
+   */
+  sendNotificationEmail: function(id) {
+    var doc = Posts.findOne(id);
+    var compiled = _.template(notificationEmailTemplate);
+    var html = compiled({code: Emails.getCode(doc.createdAt), url: Posts.getUrl(doc._id)});
+    Email.send({
+      from: EMAIL_FROM,
+      to: EMAIL_TO,
+      subject: 'textie | Response needed',
+      html: html
+    });
+  }
+
+});
+
+Emails = {
+
+  /**
+   * @param {Date|String} date - A date object or string. If a string is used, it must contain the
+   *     timezone offset (e.g. ISO format).
+   * @return {String} A code representing the timezone for the date.
+   */
+  getCode: function(date) {
+    if (!date) throw new Error('No date provided')
+
+    var hour = moment.utc(date).hours();
+    return String.fromCharCode(LETTER_START.charCodeAt(0) + hour) + '1';
+  }
+
+};
+
+// Send an email notification to admins when new posts are created.
+Posts.after.insert(function(userId, doc) {
+  Posts.sendNotificationEmail(doc._id);
+});

--- a/packages/custom/lib/server/Emails.js
+++ b/packages/custom/lib/server/Emails.js
@@ -5,6 +5,7 @@ var LETTER_START = 'A';
 
 var fs = Npm.require('fs');
 var path = Npm.require('path');
+var url = Npm.require('url');
 var assetsPath = path.join(process.cwd(), 'assets/packages/my-custom-package');
 
 var notificationEmailTemplate = fs.readFileSync(path.join(assetsPath,
@@ -56,5 +57,8 @@ Emails = {
 
 // Send an email notification to admins when new posts are created.
 Posts.after.insert(function(userId, doc) {
-  Posts.sendNotificationEmail(doc._id);
+  // Deferred to prevent blocking on the client's request.
+  _.defer(Meteor.bindEnvironment(function() {
+    Posts.sendNotificationEmail(doc._id);
+  }));
 });

--- a/packages/custom/lib/server/emails/postNotificationEmail.html
+++ b/packages/custom/lib/server/emails/postNotificationEmail.html
@@ -5,4 +5,4 @@
 <p>Thanks,<br />
 <strong>Team textie</strong></p>
 
-<p>Code:<%= code %></p>
+<p style="color: #ccc;">Code:<%= code %></p>

--- a/packages/custom/lib/server/emails/postNotificationEmail.html
+++ b/packages/custom/lib/server/emails/postNotificationEmail.html
@@ -1,0 +1,8 @@
+<p>Please suggest an appropriate response to the submitted text.</p>
+
+<p><a href="<%= url %>"><%= url %></a></p>
+
+<p>Thanks,<br />
+<strong>Team textie</strong></p>
+
+<p>Code:<%= code %></p>

--- a/packages/custom/package.js
+++ b/packages/custom/package.js
@@ -8,7 +8,12 @@ Package.onUse(function (api) {
 
   // ---------------------------------- 1. Core dependency -----------------------------------
 
-  api.use("telescope:core");
+  api.use([
+    'underscore',
+    'telescope:core@0.20.4',
+    'matb33:collection-hooks@0.8.0',
+    'momentjs:moment@2.10.3'
+  ], ['client', 'server']);
 
   // ---------------------------------- 2. Files to include ----------------------------------
 
@@ -49,13 +54,19 @@ Package.onUse(function (api) {
     'lib/client/privacy.js',
     'lib/client/templates/trending_posts.html',
     'lib/client/templates/trending_posts.js'
-  ], ['client']);
+  ], 'client');
 
   // server
 
   api.addFiles([
+    'lib/server/Emails.js',
+    'lib/server/emails/postNotificationEmail.html',
     'lib/server/templates/custom_emailPostItem.handlebars'
-  ], ['server']);
+  ], 'server');
+
+  api.export([
+    'Emails'
+  ], 'server');
 
   // i18n languages (must come last)
 
@@ -63,4 +74,21 @@ Package.onUse(function (api) {
     'i18n/en.i18n.json'
   ], ['client', 'server']);
 
+});
+
+Package.onTest(function(api) {
+  api.use([
+    'coffeescript',
+    'tinytest',
+    'test-helpers',
+    'practicalmeteor:munit',
+
+    'momentjs:moment',
+    'telescope:core',
+    'my-custom-package'
+  ], 'server');
+  api.addFiles([
+    'tests/shims.coffee',
+    'tests/EmailsSpec.coffee'
+  ], 'server');
 });

--- a/packages/custom/tests/EmailsSpec.coffee
+++ b/packages/custom/tests/EmailsSpec.coffee
@@ -1,0 +1,8 @@
+describe 'EmailsSpec', ->
+
+  it 'can generate a notification code', ->
+    startDate = moment.utc('2015-11-04T00:10:00+00:00')
+    expect(Emails.getCode(startDate)).to.equal 'A1'
+    expect(Emails.getCode(startDate.clone().add(1, 'hour'))).to.equal 'B1'
+    expect(Emails.getCode(startDate.clone().add(23, 'hour'))).to.equal 'X1'
+    expect(Emails.getCode(startDate.clone().add(24, 'hour'))).to.equal 'A1'

--- a/packages/custom/tests/shims.coffee
+++ b/packages/custom/tests/shims.coffee
@@ -1,0 +1,4 @@
+# TODO(aramk) Some package exports are not available in TinyTest so I've bound them manually.
+
+global.Users = Package['telescope:users'].Users
+global.Settings = Package['telescope:settings'].Settings


### PR DESCRIPTION
- Added an Emails module to send email notifications for posts.
- Added Posts.getUrl() to generate canonical URLs for posts.
- Added Emails.getCode() to generate the code for the given date using UTC.
- Added email template for post notification.
- Added EmailsSpec to test getCode() in TinyTest.